### PR TITLE
add utf-8 encoding to close #34

### DIFF
--- a/bin/true-cli
+++ b/bin/true-cli
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: UTF-8
 require 'sass'
 require 'true'
 require 'yaml'


### PR DESCRIPTION
This should fix the issue found in #34. I'm assuming that @utis is on Windows, as I have encountered the same issue with other libraries on my Windows machine. As far as I know, this happens when unicode characters are sent to `$stdout` (namely, `»`, from what I can find [here](https://github.com/ericam/true/blob/master/sass/true/_assert.scss#L212-L221)) in an environment that doesn't support them e.g. Windows. :+1: 